### PR TITLE
MUZIMA-430

### DIFF
--- a/src/test/java/com/muzima/api/service/CohortServiceTest.java
+++ b/src/test/java/com/muzima/api/service/CohortServiceTest.java
@@ -66,6 +66,7 @@ public class CohortServiceTest {
         String path = System.getProperty("java.io.tmpdir") + "/muzima/" + UUID.randomUUID().toString();
         ContextFactory.setProperty(Constants.LUCENE_DIRECTORY_PATH, path);
         context = ContextFactory.createContext();
+        context.setPreferredLocale("en");
         context.openSession();
         if (!context.isAuthenticated()) {
             context.authenticate("admin", "test", "http://demo2.muzima.org", true, false);

--- a/src/test/java/com/muzima/api/service/ConceptServiceTest.java
+++ b/src/test/java/com/muzima/api/service/ConceptServiceTest.java
@@ -54,6 +54,7 @@ public class ConceptServiceTest {
         String path = System.getProperty("java.io.tmpdir") + "/muzima/" + UUID.randomUUID().toString();
         ContextFactory.setProperty(Constants.LUCENE_DIRECTORY_PATH, path);
         context = ContextFactory.createContext();
+        context.setPreferredLocale("en");
         context.openSession();
         if (!context.isAuthenticated()) {
             context.authenticate("admin", "test", "http://demo2.muzima.org", true, false);

--- a/src/test/java/com/muzima/api/service/EncounterServiceTest.java
+++ b/src/test/java/com/muzima/api/service/EncounterServiceTest.java
@@ -59,6 +59,7 @@ public class EncounterServiceTest {
         String path = System.getProperty("java.io.tmpdir") + "/muzima/" + UUID.randomUUID().toString();
         ContextFactory.setProperty(Constants.LUCENE_DIRECTORY_PATH, path);
         context = ContextFactory.createContext();
+        context.setPreferredLocale("en");
         context.openSession();
         if (!context.isAuthenticated()) {
             context.authenticate("admin", "test", "http://demo2.muzima.org", true, false);

--- a/src/test/java/com/muzima/api/service/FormServiceTest.java
+++ b/src/test/java/com/muzima/api/service/FormServiceTest.java
@@ -61,6 +61,7 @@ public class FormServiceTest {
         String path = System.getProperty("java.io.tmpdir") + "/muzima/" + UUID.randomUUID().toString();
         ContextFactory.setProperty(Constants.LUCENE_DIRECTORY_PATH, path);
         context = ContextFactory.createContext();
+        context.setPreferredLocale("en");
         context.openSession();
         if (!context.isAuthenticated()) {
             context.authenticate("admin", "test", "http://demo2.muzima.org", true, false);

--- a/src/test/java/com/muzima/api/service/LocationServiceTest.java
+++ b/src/test/java/com/muzima/api/service/LocationServiceTest.java
@@ -49,6 +49,7 @@ public class LocationServiceTest {
         String path = System.getProperty("java.io.tmpdir") + "/muzima/" + UUID.randomUUID().toString();
         ContextFactory.setProperty(Constants.LUCENE_DIRECTORY_PATH, path);
         context = ContextFactory.createContext();
+        context.setPreferredLocale("en");
         context.openSession();
         if (!context.isAuthenticated()) {
             context.authenticate("admin", "test", "http://demo2.muzima.org", true, false);

--- a/src/test/java/com/muzima/api/service/NotificationServiceTest.java
+++ b/src/test/java/com/muzima/api/service/NotificationServiceTest.java
@@ -56,6 +56,7 @@ public class NotificationServiceTest {
         String path = System.getProperty("java.io.tmpdir") + "/muzima/" + UUID.randomUUID().toString();
         ContextFactory.setProperty(Constants.LUCENE_DIRECTORY_PATH, path);
         context = ContextFactory.createContext();
+        context.setPreferredLocale("en");
         context.openSession();
         if (!context.isAuthenticated()) {
             context.authenticate("admin", "test", "http://localhost:8080/openmrs", true, false);

--- a/src/test/java/com/muzima/api/service/ObservationServiceTest.java
+++ b/src/test/java/com/muzima/api/service/ObservationServiceTest.java
@@ -69,6 +69,7 @@ public class ObservationServiceTest {
         String path = System.getProperty("java.io.tmpdir") + "/muzima/" + UUID.randomUUID().toString();
         ContextFactory.setProperty(Constants.LUCENE_DIRECTORY_PATH, path);
         context = ContextFactory.createContext();
+        context.setPreferredLocale("en");
         context.openSession();
         if (!context.isAuthenticated()) {
             context.authenticate("admin", "test", "http://demo2.muzima.org", true, false);

--- a/src/test/java/com/muzima/api/service/PatientServiceTest.java
+++ b/src/test/java/com/muzima/api/service/PatientServiceTest.java
@@ -64,6 +64,7 @@ public class PatientServiceTest {
         String path = System.getProperty("java.io.tmpdir") + "/muzima/" + UUID.randomUUID().toString();
         ContextFactory.setProperty(Constants.LUCENE_DIRECTORY_PATH, path);
         context = ContextFactory.createContext();
+        context.setPreferredLocale("en");
         context.openSession();
         if (!context.isAuthenticated()) {
             context.authenticate("admin", "test", "http://demo2.muzima.org", true, false);


### PR DESCRIPTION
Tests now require locale to RESTfully consume /muzima/ namespace. We use 'en' as the test locale.